### PR TITLE
config: mongo client configured to new DB

### DIFF
--- a/Hermes/server/cmd/main.go
+++ b/Hermes/server/cmd/main.go
@@ -9,6 +9,6 @@ import (
 
 func main() {
 	r := routes.RouterInit()
-	log.Println("Starting server on Port: 5050")
-	log.Fatal(http.ListenAndServe(":5050", r))
+	log.Println("Starting server on Port: 8080")
+	log.Fatal(http.ListenAndServe(":8080", r))
 }

--- a/Hermes/server/db/mongo.go
+++ b/Hermes/server/db/mongo.go
@@ -16,7 +16,7 @@ type MongoHandler struct {
 }
 
 var (
-	defaultDB = "CryptoChasm"
+	defaultDB = "hermes"
 	TimeOut   = time.Second * 10
 )
 

--- a/server/db/mongo.go
+++ b/server/db/mongo.go
@@ -16,7 +16,7 @@ type MongoHandler struct {
 }
 
 var (
-	defaultDB = "CryptoChasm"
+	defaultDB = "warranty"
 	TimeOut   = time.Second * 10
 )
 


### PR DESCRIPTION
We don't need an underlying issue here. 
Changes have been locally tested with the API keys and we can successfully connect to `MongoDB`
```
2022/07/28 12:43:14 Connected to MongoDB
2022/07/28 12:43:14 Starting server on Port: 5050
```
Output is as expected.